### PR TITLE
Bugfix: docker stop can now stop the container without having to kill it

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -31,6 +31,7 @@ fi
 echo "=> Run the clean script every ${CLEAN_PERIOD} seconds and delay ${DELAY_TIME} seconds to clean."
 
 trap '{ echo "User Interupt."; exit 1; }' SIGINT
+trap '{ echo "SIGTERM received, exiting."; exit 0; }' SIGTERM
 while [ 1 ]
 do
     # Cleanup unused volumes


### PR DESCRIPTION
"docker stop" command sends a SIGTERM, which bash ignores by default. After 10s, docker sends SIGKILL, killing the container and reporting an error in systemd and fleet (CoreOS). This PR adds a trap for SIGTERM, which makes the docker-cleanup stop cleanly with exit code 0. I've only done minimal testing on CoreOS.

This is my first ever PR, so please tell me if I did anything wrong.
