### PR TITLE
Added ability to exclude containers from clean up.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ADD docker-cleanup-volumes.sh /docker-cleanup-volumes.sh
 ENV CLEAN_PERIOD **None**
 ENV DELAY_TIME **None**
 ENV KEEP_IMAGES **None**
+ENV KEEP_CONTAINERS **None**
 ENV LOOP true
 
 ENTRYPOINT ["/run.sh"]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Docker Cleanup
-This image will periodically clean up exited containers and remove images and volumes that aren't in use by a 
-running container. Based on [tutumcloud/image-cleanup](https://github.com/tutumcloud/image-cleanup) and 
+This image will periodically clean up exited containers and remove images and volumes that aren't in use by a
+running container. Based on [tutumcloud/image-cleanup](https://github.com/tutumcloud/image-cleanup) and
 [chadoe/docker-cleanup-volumes](https://github.com/chadoe/docker-cleanup-volumes) with some small fixes.
 
-Normally any Docker containers that exit are still kept on disk until *docker rm -v* is used to clean 
-them up. Similarly any images that aren't used any more are kept around. For a cluster node that see 
-lots of containers start and stop, large amounts of exited containers and old image versions can fill 
-up the disk. A Jenkins build slave has the same issues, but can also suffer from SNAPSHOT images being 
+Normally any Docker containers that exit are still kept on disk until *docker rm -v* is used to clean
+them up. Similarly any images that aren't used any more are kept around. For a cluster node that see
+lots of containers start and stop, large amounts of exited containers and old image versions can fill
+up the disk. A Jenkins build slave has the same issues, but can also suffer from SNAPSHOT images being
 continuously rebuilt and causing untagged <none> images to be left around.
 
 ## Environment Variables
@@ -15,6 +15,7 @@ The default parameters can be overridden by setting environment variables on the
  * **CLEAN_PERIOD=1800** - Interval in seconds to sleep after completing a cleaning run. Defaults to 1800 seconds = 30 minutes.
  * **DELAY_TIME=1800** - Seconds to wait before removing exited containers and unused images. Defaults to 1800 seconds = 30 minutes.
  * **KEEP_IMAGES** - List of images to avoid cleaning, e.g. "ubuntu:trusty, ubuntu:latest". Defaults to clean all unused images.
+ * **KEEP_CONTAINERS** - List of images for exited or dead containers to avoid cleaning, e.g. "ubuntu:trusty, ubuntu:latest".
  * **LOOP** - Add the ability to do non-looped cleanups, run it once and exit. Options are true, false. Defaults to true to run it forever in loops.
 
 ## Deployment
@@ -24,7 +25,7 @@ If the */var/lib/docker* directory is mapped into the container this script will
 
 ### Systemd and CoreOS/Fleet
 
-Create a [Systemd unit](http://www.freedesktop.org/software/systemd/man/systemd.unit.html) file 
+Create a [Systemd unit](http://www.freedesktop.org/software/systemd/man/systemd.unit.html) file
 in **/etc/systemd/system/docker-cleanup.service** with contents like below. Using CoreOS and
 [Fleet](https://coreos.com/docs/launching-containers/launching/fleet-unit-files/) then
 add the X-Fleet section to schedule the unit on all cluster nodes.


### PR DESCRIPTION
There are some scenarios where you want an exited container to remain (e.g. data-only containers). So, we added logic to specify the images being used in those containers so that they are not removed.

Thanks
