### PR TITLE
Allow for Image Id's w/ sha256: Prefix

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -73,7 +73,7 @@ do
     rm -f ContainerImageIdList
     touch ContainerImageIdList
     for CONTAINER_ID in ${CONTAINER_ID_LIST}; do
-        LINE=$(docker inspect ${CONTAINER_ID} | grep "\"Image\": \"[0-9a-fA-F]\{64\}\"")
+        LINE=$(docker inspect ${CONTAINER_ID} | grep "\"Image\": \"\(sha256:\)\?[0-9a-fA-F]\{64\}\"")
         IMAGE_ID=$(echo ${LINE} | awk -F '"' '{print $4}')
         echo "${IMAGE_ID}" >> ContainerImageIdList
     done
@@ -89,7 +89,7 @@ do
         arr=$(echo ${KEEP_IMAGES} | tr "," "\n")
         for x in $arr
         do
-            docker inspect $x | grep "\"Id\": \"[0-9a-fA-F]\{64\}\"" | head -1 | awk -F '"' '{print $4}'  >> KeepImageIdList
+            docker inspect $x | grep "\"Id\": \"\(sha256:\)\?[0-9a-fA-F]\{64\}\"" | head -1 | awk -F '"' '{print $4}'  >> KeepImageIdList
         done
         sort KeepImageIdList -o KeepImageIdList
         comm -23 ToBeCleanedImageIdList KeepImageIdList > ToBeCleanedImageIdList2
@@ -113,7 +113,7 @@ do
     rm -f ContainerImageIdList
     touch ContainerImageIdList
     for CONTAINER_ID in ${CONTAINER_ID_LIST}; do
-        LINE=$(docker inspect ${CONTAINER_ID} | grep "\"Image\": \"[0-9a-fA-F]\{64\}\"")
+        LINE=$(docker inspect ${CONTAINER_ID} | grep "\"Image\": \"\(sha256:\)\?[0-9a-fA-F]\{64\}\"")
         IMAGE_ID=$(echo ${LINE} | awk -F '"' '{print $4}')
         echo "${IMAGE_ID}" >> ContainerImageIdList
     done


### PR DESCRIPTION
It would appear that [v1.10.0](https://github.com/docker/docker/releases/tag/v1.10.0) introduced a change to the image id's. Now when I inspect an image (or container) the id is prefixed with "sha256:".

``` sh
> docker --version
Docker version 1.9.1, build a34a1d5

> docker inspect alpine:latest
[
    {
        "Id": "3571dd565f47a963b6a35523bd3912aecba747e2a24d1f9be0157c8cf5eb07f2",
        ...
    }
]
```

``` sh
> docker --version
Docker version 1.10.0, build 590d5108

> docker inspect alpine:latest
[
    {
        "Id": "sha256:90239124c3524df365bfd1dc0329c383d37f07c22f86e0aaa1f4f00011d56da3",
        ...
    }
]
```
