### PR TITLE
fix single ENV syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,18 @@
 FROM alpine:latest
 
+ENTRYPOINT ["/run.sh"]
+
+ENV CLEAN_PERIOD=**None** \
+    DELAY_TIME=**None** \
+    KEEP_IMAGES=**None** \
+    KEEP_CONTAINERS=**None** \
+    LOOP=true \
+    DEBUG=0
+
 # run.sh script uses some bash specific syntax
 RUN apk add --update bash docker grep
 
-ENV CLEAN_PERIOD **None** DELAY_TIME **None** KEEP_IMAGES **None** KEEP_CONTAINERS **None** LOOP true DEBUG 0
-
-# Reorder for efficiency
 # Install cleanup script
 ADD docker-cleanup-volumes.sh /docker-cleanup-volumes.sh
 ADD run.sh /run.sh
 
-ENTRYPOINT ["/run.sh"]


### PR DESCRIPTION
Hi,

With our latest release using yesterday's container build, we've seen a spike in CPU usage for docker-cleanup.

```
CONTAINER           CPU %               MEM USAGE / LIMIT     MEM %               NET I/O             BLOCK I/O
9b5cb62b6772        109.55%             585.7 kB / 52.43 MB   1.12%               2.676 kB / 648 B    0 B / 3.092 MB
```

The latest change to move `ENV` to single line is missing required `=` signs as outlined in the docs, and causes the env vars to be incorrectly set: https://docs.docker.com/engine/reference/builder/#env

```
❯ docker run --rm -it --entrypoint=/bin/sh meltwater/docker-cleanup -c "printenv"
HOSTNAME=bd91acb68f4f
SHLVL=1
HOME=/root
TERM=xterm
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
CLEAN_PERIOD=**None** DELAY_TIME **None** KEEP_IMAGES **None** KEEP_CONTAINERS **None** LOOP true DEBUG 0
PWD=/
```

This PR shows env correctly:

```
❯ docker run --rm -it --entrypoint=/bin/sh cleanup -c "printenv"
DEBUG=0
HOSTNAME=a7649a49780d
SHLVL=1
HOME=/root
KEEP_CONTAINERS=**None**
LOOP=true
TERM=xterm
DELAY_TIME=**None**
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
CLEAN_PERIOD=**None**
PWD=/
KEEP_IMAGES=**None**
```

thanks 
