### PR TITLE
Added support to keep containers by their container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,11 @@ The default parameters can be overridden by setting environment variables on the
  * **DELAY_TIME=1800** - Seconds to wait before removing exited containers and unused images. Defaults to 1800 seconds = 30 minutes.
  * **KEEP_IMAGES** - List of images to avoid cleaning, e.g. "ubuntu:trusty, ubuntu:latest". Defaults to clean all unused images.
  * **KEEP_CONTAINERS** - List of images for exited or dead containers to avoid cleaning, e.g. "ubuntu:trusty, ubuntu:latest".
+ * **KEEP_CONTAINERS_NAMED** - List of names for exited or dead containers to avoid cleaning, e.g. "my-container1, persistent-data".
  * **LOOP** - Add the ability to do non-looped cleanups, run it once and exit. Options are true, false. Defaults to true to run it forever in loops.
  * **DEBUG** - Set to 1 to enable more debugging output on pattern matches
 
-Note that **KEEP_IMAGES** and **KEEP_CONTAINERS** are left-anchored bash shell pattern matching lists (NOT regexps).  Therefore, the image **foo/bar:tag** will be matched by ANY of the following:
+Note that **KEEP_IMAGES**, **KEEP_CONTAINERS**, and **KEEP_CONTAINERS_NAMED** are left-anchored bash shell pattern matching lists (NOT regexps).  Therefore, the image **foo/bar:tag** will be matched by ANY of the following:
 
  * foo/bar:tag
  * foo/bar

--- a/run.sh
+++ b/run.sh
@@ -35,6 +35,13 @@ if [ "${KEEP_CONTAINERS}" == "**All**" ]; then
     KEEP_CONTAINERS="."
 fi
 
+if [ "${KEEP_CONTAINERS_NAMED}" == "**None**" ]; then
+    unset KEEP_CONTAINERS_NAMED
+fi
+if [ "${KEEP_CONTAINERS_NAMED}" == "**All**" ]; then
+    KEEP_CONTAINERS_NAMED="."
+fi
+
 if [ "${LOOP}" != "false" ]; then
     LOOP=true
 fi
@@ -65,11 +72,22 @@ do
     EXITED_CONTAINERS_IDS="`docker ps -a -q -f status=exited -f status=dead | xargs echo`"
     for CONTAINER_ID in $EXITED_CONTAINERS_IDS; do
       CONTAINER_IMAGE=$(docker inspect --format='{{(index .Config.Image)}}' $CONTAINER_ID)
-      if [ $DEBUG ]; then echo "DEBUG: Check container $CONTAINER_IMAGE"; fi
+      CONTAINER_NAME=$(docker inspect --format='{{(index .Name)}}' $CONTAINER_ID)
+      if [ $DEBUG ]; then echo "DEBUG: Check container image $CONTAINER_IMAGE named $CONTAINER_NAME"; fi
       keepit=0
       if [ -n "${KEEP_CONTAINERS}" ]; then
         for PATTERN in $(echo ${KEEP_CONTAINERS} | tr "," "\n"); do
           if [[ "${CONTAINER_IMAGE}" = $PATTERN* ]]; then
+            if [ $DEBUG ]; then echo "DEBUG: Matches $PATTERN - keeping"; fi
+            keepit=1
+          else
+            if [ $DEBUG ]; then echo "DEBUG: No match for $PATTERN"; fi
+          fi
+        done
+      fi
+      if [ -n "${KEEP_CONTAINERS_NAMED}" ]; then
+        for PATTERN in $(echo ${KEEP_CONTAINERS_NAMED} | tr "," "\n"); do
+          if [[ "${CONTAINER_NAME}" = $PATTERN* ]]; then
             if [ $DEBUG ]; then echo "DEBUG: Matches $PATTERN - keeping"; fi
             keepit=1
           else

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,20 @@
 #!/bin/bash
 
+checkPatterns() {
+    keepit=$3
+    if [ -n "$1" ]; then
+        for PATTERN in $(echo $1 | tr "," "\n"); do
+        if [[ "$2" = $PATTERN* ]]; then
+            if [ $DEBUG ]; then echo "DEBUG: Matches $PATTERN - keeping"; fi
+            keepit=1
+        else
+            if [ $DEBUG ]; then echo "DEBUG: No match for $PATTERN"; fi
+        fi
+        done
+    fi
+    return $keepit
+}
+
 if [ ! -e "/var/run/docker.sock" ]; then
     echo "=> Cannot find docker socket(/var/run/docker.sock), please check the command!"
     exit 1
@@ -75,26 +90,10 @@ do
       CONTAINER_NAME=$(docker inspect --format='{{(index .Name)}}' $CONTAINER_ID)
       if [ $DEBUG ]; then echo "DEBUG: Check container image $CONTAINER_IMAGE named $CONTAINER_NAME"; fi
       keepit=0
-      if [ -n "${KEEP_CONTAINERS}" ]; then
-        for PATTERN in $(echo ${KEEP_CONTAINERS} | tr "," "\n"); do
-          if [[ "${CONTAINER_IMAGE}" = $PATTERN* ]]; then
-            if [ $DEBUG ]; then echo "DEBUG: Matches $PATTERN - keeping"; fi
-            keepit=1
-          else
-            if [ $DEBUG ]; then echo "DEBUG: No match for $PATTERN"; fi
-          fi
-        done
-      fi
-      if [ -n "${KEEP_CONTAINERS_NAMED}" ]; then
-        for PATTERN in $(echo ${KEEP_CONTAINERS_NAMED} | tr "," "\n"); do
-          if [[ "${CONTAINER_NAME}" = $PATTERN* ]]; then
-            if [ $DEBUG ]; then echo "DEBUG: Matches $PATTERN - keeping"; fi
-            keepit=1
-          else
-            if [ $DEBUG ]; then echo "DEBUG: No match for $PATTERN"; fi
-          fi
-        done
-      fi
+      checkPatterns "${KEEP_CONTAINERS}" "${CONTAINER_IMAGE}" $keepit
+      keepit=$?
+      checkPatterns "${KEEP_CONTAINERS_NAMED}" "${CONTAINER_NAME}" $keepit
+      keepit=$?
       if [[ $keepit -eq 0 ]]; then
         echo "Removing stopped container $CONTAINER_ID"
         docker rm -v $CONTAINER_ID


### PR DESCRIPTION
I added a variable called KEEP_CONTAINERS_NAMED which allows you to save containers by their container name instead of just matching on image name.

I am using this to keep around all containers with names like "*-data", since that is the convention I use for my data volume containers.
