### PR TITLE
add support for DOCKER_API_VERSION

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ENV CLEAN_PERIOD=**None** \
     KEEP_IMAGES=**None** \
     KEEP_CONTAINERS=**None** \
     LOOP=true \
-    DEBUG=0
+    DEBUG=0 \
+    DOCKER_API_VERSION=1.20
 
 # run.sh script uses some bash specific syntax
 RUN apk add --update bash docker grep

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The default parameters can be overridden by setting environment variables on the
  * **KEEP_CONTAINERS_NAMED** - List of names for exited or dead containers to avoid cleaning, e.g. "my-container1, persistent-data".
  * **LOOP** - Add the ability to do non-looped cleanups, run it once and exit. Options are true, false. Defaults to true to run it forever in loops.
  * **DEBUG** - Set to 1 to enable more debugging output on pattern matches
+ * **DOCKER_API_VERSION** - The docker API version to use. This defaults to 1.20, but you can override it here in case the docker version on your host differs from the one that is installed in this container. You can find this on your host system by running `docker version --format '{{.Client.APIVersion}}'`.
 
 Note that **KEEP_IMAGES**, **KEEP_CONTAINERS**, and **KEEP_CONTAINERS_NAMED** are left-anchored bash shell pattern matching lists (NOT regexps).  Therefore, the image **foo/bar:tag** will be matched by ANY of the following:
 


### PR DESCRIPTION
Fixes #13. The latest version of alpine now has docker 1.11, which supports the DOCKER_API_VERSION environment variable. This change makes that value default to 1.20 (for backwards compatibility), and allows it to be overridden to other versions.

I've tested this on a couple of different docker versions. The default API version (1.20) seems to work fine on a docker 1.11.1 host system, and overriding it to the latest API version (1.23) also works.

Unfortunately, it doesn't seem to quite work for docker 1.7.1 on the host system (API version 1.19). I don't have access to other systems to test, but would be curious if it works on docker 1.8 systems.
