### PR TITLE
apply whitelist to created containers

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -192,7 +192,9 @@ do
     if [ -s CreatedContainerToClean ]; then
         echo "=> Start to clean $(cat CreatedContainerToClean | wc -l) created/stuck containers"
         if [ $DEBUG ]; then echo "DEBUG: Removing unstarted containers"; fi
-        docker rm -v $(cat CreatedContainerToClean)
+        for CONTAINER_ID in $(cat CreatedContainerToClean); do
+            deleteContainer $CONTAINER_ID
+        done
     fi
 
     # Remove images being used by containers from the delete list again. This prevents the images being pulled from deleting


### PR DESCRIPTION
Originally, this breaks certain services like [Aqua](https://www.aquasec.com/), which creates a container that just exists on the system.

All I did was:
- move the pattern matching logic for a given `CONTAINER_ID` into two functions
    - `containerMatches()` for pattern matching
    - `deleteContainer()` for deletion/logging
- run the `CreatedContainerToClean` list through the whitelist

Feedback/suggestions are welcome! Thanks for the nice tool 😄 