### PR TITLE
Allow images that have multiple tags to be deleted too

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -196,7 +196,7 @@ do
     # Remove Images
     if [ -s ToBeCleaned ]; then
         echo "=> Start to clean $(cat ToBeCleaned | wc -l) images"
-        docker rmi $(cat ToBeCleaned) 2>/dev/null
+        docker rmi -f $(cat ToBeCleaned) 2>/dev/null
         (( DIFF_LAYER=${ALL_LAYER_NUM}- $(docker images -a | tail -n +2 | wc -l) ))
         (( DIFF_IMG=$(cat ImageIdList | wc -l) - $(docker images | tail -n +2 | wc -l) ))
         if [ ! ${DIFF_LAYER} -gt 0 ]; then


### PR DESCRIPTION
On our platform, it's customary to retag images with the latest commit-id from the git repository without rebuilding the image when this part of the code hasn't changed.
So on our integration platforms, we end up with one image having 2 to hundreds of tags.
Docker requires the "--force/-f" option to be passed to `docker rmi` when an image is referenced several times.

This PR fixes that. (tested at home successfully)